### PR TITLE
chore: add commitizen adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # eslint-config-ca
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
 
 This module is intended to be used in all CA React components and applications
 
@@ -22,3 +23,11 @@ Once the `eslint-config-ca` package is installed, you can use it by specifying `
   }
 }
 ```
+
+
+## Contributing
+
+This project supports `commitizen`. You can use `npm run commit` to run the local instance of `commitizen` or `git cz` if you have it installed globally.
+
+Alternatively, if you are simply using `git commit`, you must follow this format:
+`git commit -m "<type>: <subject>"`

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "test": "node test/test.js",
-    "commitmsg": "validate-commit-msg"
+    "commitmsg": "validate-commit-msg",
+    "commit": "git-cz"
   },
   "dependencies": {
     "eslint": "^3.5.0",


### PR DESCRIPTION
This Commit adds `commitizen`, `validate-commit-msg` and `cz-conventional-changelog` functionality to this repo, as per https://rally1.rallydev.com/#/63515825210ud/detail/userstory/78741891276

Commit messages for this project will now have to be structured in this format: 
`git commit -m "<type>: <subject>"`

e.g. `git commit -m "chore: add commitizen adapter"`

CC: @alebiavati @shanedasilva @bevanhunt 
