### PR TITLE
fix: remove require-default-props rule in favour of Flowtype

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,18 @@ module.exports = {
     'react/jsx-filename-extension': [2, {
       extensions: ['.js', '.jsx']
     }],
+    
+    /**
+     * We use Flow for our components props and we define default prop values
+     * when destructing the props object in the render method of the components.
+     * Example:
+     *   const ComponentName = ({ test = 'data' }: Props) => { ... };
+     *
+     * `react/require-default-props` doesn't see these default values and throws an error.
+     * Flow understands these default values and it will still throw if a possibly
+     * undefined prop is passed to a function that requires a defined value.
+     */
+    'react/require-default-props': 0,
 
     // allow use of unary operators, ++ and --
     'no-plusplus': 0,


### PR DESCRIPTION
## Status
**READY**

## Description
We use Flow for our components props and we define default prop values
when destructing the props object in the render method of the components.

Example:
```js
const ComponentName = ({ test = 'data' }: Props) => { ... };
```

`react/require-default-props` doesn't see these default values and throws an error.
Flow understands these default values and it will still throw if a possibly
undefined prop is passed to a function that requires a defined value.
